### PR TITLE
feat(reportes): agregar token de seguimiento para reportes anónimos

### DIFF
--- a/backend/prisma/migrations/20260515061909_add_token_seguimiento_reporte/migration.sql
+++ b/backend/prisma/migrations/20260515061909_add_token_seguimiento_reporte/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[token_seguimiento]` on the table `Reporte` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "Reporte" ADD COLUMN     "token_seguimiento" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Reporte_token_seguimiento_key" ON "Reporte"("token_seguimiento");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -249,6 +249,7 @@ model Reporte {
   estado             EstadoIncidencia
   prioridad          PrioridadReporte
   es_anonimo         Boolean
+  token_seguimiento  String? @unique
   resultado_esperado String?          @db.Text
   resultado_solucion String?          @db.Text
 


### PR DESCRIPTION
Se agregó el campo token_seguimiento al modelo Reporte y la lógica para generar un token único cuando es_anonimo es true, cumpliendo con el criterio CA011 de la HU-4.4.2.