### PR TITLE
HU-1.2.1 Generación de QR para visitas

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -751,6 +751,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1501,7 +1502,8 @@
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.1.tgz",
       "integrity": "sha512-mZ9NzzUSYPOCnxHH1oAHPRzoMFJHY472raDKwXl/+6oPbpdJ7g8LsCN4FSaIIfkiCKHhb3iF/Zqo3NYxaIhU7Q==",
       "devOptional": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.1.1",
@@ -3425,6 +3427,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@nestjs-modules/mailer/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@nestjs-modules/mailer/node_modules/nunjucks": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.4.tgz",
@@ -3449,6 +3464,32 @@
         "chokidar": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs-modules/mailer/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@nestjs-modules/mailer/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/@nestjs/cli": {
@@ -3502,6 +3543,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3672,6 +3714,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.19.tgz",
       "integrity": "sha512-qeiTt2tv+e5QyDKqG8HlVZb2wx64FEaSGFJouqTSRs+kG44iTfl3xlz1XqVped+rihx4hmjWgL5gkhtdK3E6+Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "21.3.4",
         "iterare": "1.2.1",
@@ -3731,6 +3774,7 @@
       "integrity": "sha512-6nJkWa2efrYi+XlU686J9y5L7OvxpLVjT0T/sxRKE7Jvpffiihelup4WSvLvRhdHDjj/5SuoWEwqReXAaaeHmw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -3814,6 +3858,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.19.tgz",
       "integrity": "sha512-Vpdv8jyCQdThfoTx+UTn+DRYr6H6X02YUqcpZ3qP6G3ZUwtVp7eS+hoQPGd4UuCnlnFG8Wqr2J9bGEzQdi1rIg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -3835,6 +3880,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-11.1.21.tgz",
       "integrity": "sha512-Tq5JgaVS+auD3DXuRBy8UMU3mf69HJO8Ep+BuRS9GYMXGd/5sdMHqIQvXlXkGih9tQXdeeG9WoqURe/+IjPKng==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "socket.io": "4.8.3",
         "tslib": "2.8.1"
@@ -3949,6 +3995,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-11.1.21.tgz",
       "integrity": "sha512-2L+jFf6Nbjv7WacngvSoYGYTalqNuXlOkFl9Q5e92XiPK4gR6c4Zw6zFcb7btTY5zf7pITvOoAJIGwf3+gciRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "iterare": "1.2.1",
         "object-hash": "3.0.0",
@@ -4029,6 +4076,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -4787,6 +4835,7 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -4816,6 +4865,7 @@
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -4949,6 +4999,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -5181,6 +5232,7 @@
       "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -5943,6 +5995,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5992,6 +6045,7 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6526,6 +6580,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6916,13 +6971,15 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/class-validator": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
       "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -7378,27 +7435,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/cssnano": {
-      "version": "7.1.9",
-      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.1.9.tgz",
-      "integrity": "sha512-uPR75+5Dk/WJ/YSPR1/YDHdwMM9c5FsaARljfKWgeCKLKOtJ0we21xy/RcCjn53fZnD/f6yYEIZ8pu18+GnbNQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "cssnano-preset-default": "^7.0.17",
-        "lilconfig": "^3.1.3"
-      },
-      "engines": {
-        "node": "^18.12.0 || ^20.9.0 || >=22.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/cssnano"
-      },
-      "peerDependencies": {
-        "postcss": "^8.5.13"
-      }
-    },
     "node_modules/cssnano-preset-default": {
       "version": "7.0.17",
       "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-7.0.17.tgz",
@@ -7517,8 +7553,7 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -8314,6 +8349,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8374,6 +8410,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -8606,6 +8643,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -9470,6 +9508,7 @@
       "integrity": "sha512-FbJJNb/XgX7YW0hX/V8w5oYLztKEsRLykCMZWt1WdLtsfjzMvmoqWBA4H4t5norinq8/rh20oiZYr+WSl4UzAQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -10127,6 +10166,7 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -12522,6 +12562,7 @@
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.7.tgz",
       "integrity": "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow==",
       "license": "MIT-0",
+      "peer": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -12928,6 +12969,7 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -13090,6 +13132,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -13302,35 +13345,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/postcss-calc": {
@@ -13992,6 +14006,7 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -14104,6 +14119,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "7.8.0",
         "@prisma/dev": "0.24.3",
@@ -14493,7 +14509,8 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/remeda": {
       "version": "2.33.4",
@@ -14658,6 +14675,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -14703,8 +14721,7 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/schema-utils": {
       "version": "3.3.0",
@@ -15481,6 +15498,7 @@
       "integrity": "sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==",
       "devOptional": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -15534,6 +15552,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -15865,6 +15884,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -16032,6 +16052,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16466,7 +16487,6 @@
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -16485,7 +16505,6 @@
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -16499,7 +16518,6 @@
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -16514,7 +16532,6 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -16524,8 +16541,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/webpack/node_modules/schema-utils": {
       "version": "4.3.3",
@@ -16533,7 +16549,6 @@
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1047.0",
+        "@css-inline/css-inline-linux-x64-gnu": "^0.20.2",
         "@nestjs-modules/mailer": "^2.3.4",
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.4",
@@ -1426,6 +1427,21 @@
       ],
       "license": "MIT",
       "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@css-inline/css-inline-linux-x64-gnu": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@css-inline/css-inline-linux-x64-gnu/-/css-inline-linux-x64-gnu-0.20.2.tgz",
+      "integrity": "sha512-wlTPGG1zzRdUWJHXCqetbTAf+YyilEiwmbZqtWjVRis3ZAspF0LdJmkxUv9iS5PF8kZrD0pBOGlMhKD2/Trw/g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
       "os": [
         "linux"
       ],

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1047.0",
+    "@css-inline/css-inline-linux-x64-gnu": "^0.20.2",
     "@nestjs-modules/mailer": "^2.3.4",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.4",

--- a/backend/src/visitante/visitante.controller.ts
+++ b/backend/src/visitante/visitante.controller.ts
@@ -42,7 +42,7 @@ export class VisitanteController {
           new MaxFileSizeValidator({ maxSize: 1024 * 1024 * 10 }), // 10MB
           new FileTypeValidator({ fileType: '.(png|jpeg|jpg)' }),
         ],
-        fileIsRequired: true,
+        fileIsRequired: false,
       }),
     )
     file?: Express.Multer.File,
@@ -52,6 +52,36 @@ export class VisitanteController {
       req.user.userId,
       file,
     );
+  }
+
+  @Post('accesos/:idAcceso/generar-qr')
+  @UseGuards(AuthGuard('jwt'), RolesGuard)
+  @Roles('Residente')
+  generarQr(
+    @Param('idAcceso') idAcceso: string,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    return this.visitanteService.generarQrParaVisita(
+      idAcceso,
+      req.user.userId,
+    );
+  }
+
+  @Get('accesos/:idAcceso')
+  @UseGuards(AuthGuard('jwt'), RolesGuard)
+  @Roles('Residente', 'Guardia', 'Administrador')
+  obtenerDetalleVisita(
+    @Param('idAcceso') idAcceso: string,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    return this.visitanteService.obtenerDetalleVisita(idAcceso, req.user);
+  }
+
+  @Get('qr/:codigoQr')
+  @UseGuards(AuthGuard('jwt'), RolesGuard)
+  @Roles('Guardia', 'Administrador')
+  consultarQr(@Param('codigoQr') codigoQr: string) {
+    return this.visitanteService.consultarQr(codigoQr);
   }
 
   @Get()

--- a/backend/src/visitante/visitante.service.ts
+++ b/backend/src/visitante/visitante.service.ts
@@ -5,13 +5,14 @@ import {
   NotFoundException,
   InternalServerErrorException,
   BadRequestException,
+  ForbiddenException,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateVisitanteDto } from './dto/create-visitante.dto';
 import { UpdateVisitanteDto } from './dto/update-visitante.dto';
 import 'multer';
-import { randomStringGenerator } from '@nestjs/common/utils/random-string-generator.util';
 import { ArchivosService } from '../r2-module/archivos.service';
+import { randomBytes } from 'crypto';
 
 @Injectable()
 export class VisitanteService {
@@ -19,6 +20,20 @@ export class VisitanteService {
     private prisma: PrismaService,
     private readonly archivosService: ArchivosService,
   ) {}
+
+  private generarTokenQr(): string {
+    return `qr_${randomBytes(32).toString('base64url')}`;
+  }
+
+  private calcularEstadoQr(acceso: {
+    codigo_qr: string | null;
+    fecha_expiracion: Date;
+    estatus: 'Activo' | 'Inactivo';
+  }) {
+    if (new Date(acceso.fecha_expiracion) < new Date()) return 'EXPIRADO';
+    if (acceso.estatus !== 'Activo') return 'INACTIVO';
+    return acceso.codigo_qr ? 'ACTIVO' : 'PENDIENTE_GENERACION';
+  }
 
   async create(
     createVisitanteDto: CreateVisitanteDto,
@@ -46,7 +61,8 @@ export class VisitanteService {
       ? await this.archivosService.subirImagen(file, '/visitantes')
       : null;
 
-    //Registramos al visitante con sus datos
+    // Registramos al visitante con sus datos. El QR se genera despues,
+    // cuando el residente use la accion explicita "Generar QR".
     return await this.prisma.$transaction(async (prisma) => {
       try {
         const visitante = await prisma.visitante.create({
@@ -64,9 +80,20 @@ export class VisitanteService {
               create: {
                 id_usuario: id_usuario,
                 estatus: 'Activo',
-                codigo_qr: randomStringGenerator(),
+                codigo_qr: null,
                 fecha_creacion: dataVisitante.fecha_inicio,
                 fecha_expiracion: fechaExpiracion,
+              },
+            },
+          },
+          include: {
+            accesos: {
+              select: {
+                id_acceso: true,
+                codigo_qr: true,
+                fecha_creacion: true,
+                fecha_expiracion: true,
+                estatus: true,
               },
             },
           },
@@ -77,6 +104,214 @@ export class VisitanteService {
         throw new InternalServerErrorException('Failed to create visitante');
       }
     });
+  }
+
+  async generarQrParaVisita(idAcceso: string, idUsuario: string) {
+    const acceso = await this.prisma.acceso.findUnique({
+      where: { id_acceso: idAcceso },
+      include: {
+        visitante: {
+          include: {
+            residente: {
+              select: {
+                id_usuario: true,
+                vivienda: { select: { numero_vivienda: true } },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!acceso || !acceso.visitante) {
+      throw new NotFoundException('Visita no encontrada.');
+    }
+
+    if (acceso.visitante.residente.id_usuario !== idUsuario) {
+      throw new ForbiddenException('No tienes permiso para generar este QR.');
+    }
+
+    const camposFaltantes: string[] = [];
+    if (!acceso.visitante.nombre) camposFaltantes.push('nombre');
+    if (!acceso.fecha_creacion) camposFaltantes.push('fecha de visita');
+    if (!acceso.fecha_expiracion) camposFaltantes.push('fecha/hora de expiracion');
+    if (!acceso.visitante.motivo) camposFaltantes.push('tipo de visitante');
+
+    if (camposFaltantes.length > 0) {
+      throw new BadRequestException({
+        message: 'No se puede generar el QR: faltan datos requeridos.',
+        campos: camposFaltantes,
+      });
+    }
+
+    if (new Date(acceso.fecha_expiracion) < new Date()) {
+      await this.prisma.acceso.update({
+        where: { id_acceso: idAcceso },
+        data: { estatus: 'Inactivo' },
+      });
+      throw new BadRequestException('La visita ya expiro; el QR no es valido.');
+    }
+
+    if (acceso.codigo_qr) {
+      return {
+        success: true,
+        message: 'El QR ya habia sido generado para esta visita.',
+        data: {
+          id_acceso: acceso.id_acceso,
+          id_visitante: acceso.id_visitante,
+          codigo_qr: acceso.codigo_qr,
+          estado_qr: this.calcularEstadoQr(acceso),
+          fecha_visita: acceso.fecha_creacion,
+          fecha_expiracion: acceso.fecha_expiracion,
+        },
+      };
+    }
+
+    try {
+      for (let intento = 0; intento < 5; intento += 1) {
+        try {
+          const codigoQr = this.generarTokenQr();
+          const actualizado = await this.prisma.acceso.update({
+            where: { id_acceso: idAcceso },
+            data: { codigo_qr: codigoQr },
+            select: {
+              id_acceso: true,
+              id_visitante: true,
+              codigo_qr: true,
+              fecha_creacion: true,
+              fecha_expiracion: true,
+              estatus: true,
+            },
+          });
+
+          return {
+            success: true,
+            message: 'QR generado correctamente.',
+            data: {
+              ...actualizado,
+              estado_qr: this.calcularEstadoQr(actualizado),
+            },
+          };
+        } catch (error: any) {
+          if (error?.code !== 'P2002') throw error;
+        }
+      }
+
+      throw new InternalServerErrorException(
+        'No fue posible generar un QR unico.',
+      );
+    } catch (error) {
+      if (error instanceof InternalServerErrorException) throw error;
+      throw new InternalServerErrorException('Error tecnico al generar el QR.');
+    }
+  }
+
+  async obtenerDetalleVisita(
+    idAcceso: string,
+    requestedBy: { userId: string; role: string },
+  ) {
+    const acceso = await this.prisma.acceso.findUnique({
+      where: { id_acceso: idAcceso },
+      include: {
+        visitante: {
+          include: {
+            residente: {
+              select: {
+                id_usuario: true,
+                vivienda: { select: { numero_vivienda: true } },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!acceso || !acceso.visitante) {
+      throw new NotFoundException('Visita no encontrada.');
+    }
+
+    if (
+      requestedBy.role === 'Residente' &&
+      acceso.visitante.residente.id_usuario !== requestedBy.userId
+    ) {
+      throw new ForbiddenException('No tienes permiso para ver esta visita.');
+    }
+
+    const estadoQr = this.calcularEstadoQr(acceso);
+    if (estadoQr === 'EXPIRADO' && acceso.estatus !== 'Inactivo') {
+      await this.prisma.acceso.update({
+        where: { id_acceso: idAcceso },
+        data: { estatus: 'Inactivo' },
+      });
+    }
+
+    return {
+      success: true,
+      data: {
+        id_acceso: acceso.id_acceso,
+        id_visitante: acceso.id_visitante,
+        visitante: {
+          nombre: acceso.visitante.nombre,
+          telefono: acceso.visitante.telefono,
+          tipo_visitante: acceso.visitante.motivo,
+          tipo_vehiculo: acceso.visitante.tipo_vehiculo,
+          es_frecuente: acceso.visitante.es_frecuente,
+          url_imagen: acceso.visitante.url_imagen,
+        },
+        vivienda: acceso.visitante.residente.vivienda.numero_vivienda,
+        codigo_qr: acceso.codigo_qr,
+        estado_qr: estadoQr,
+        fecha_visita: acceso.fecha_creacion,
+        fecha_expiracion: acceso.fecha_expiracion,
+        estatus: estadoQr === 'EXPIRADO' ? 'Inactivo' : acceso.estatus,
+      },
+    };
+  }
+
+  async consultarQr(codigoQr: string) {
+    const acceso = await this.prisma.acceso.findUnique({
+      where: { codigo_qr: codigoQr },
+      include: {
+        visitante: {
+          include: {
+            residente: {
+              select: {
+                vivienda: { select: { numero_vivienda: true } },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!acceso || !acceso.visitante) {
+      throw new NotFoundException('QR no encontrado.');
+    }
+
+    const estadoQr = this.calcularEstadoQr(acceso);
+    if (estadoQr === 'EXPIRADO' && acceso.estatus !== 'Inactivo') {
+      await this.prisma.acceso.update({
+        where: { id_acceso: acceso.id_acceso },
+        data: { estatus: 'Inactivo' },
+      });
+    }
+
+    return {
+      success: true,
+      data: {
+        valido: estadoQr === 'ACTIVO',
+        estado_qr: estadoQr,
+        id_acceso: acceso.id_acceso,
+        id_visitante: acceso.id_visitante,
+        visitante: {
+          nombre: acceso.visitante.nombre,
+          tipo_visitante: acceso.visitante.motivo,
+        },
+        vivienda: acceso.visitante.residente.vivienda.numero_vivienda,
+        fecha_visita: acceso.fecha_creacion,
+        fecha_expiracion: acceso.fecha_expiracion,
+      },
+    };
   }
 
   findAll() {


### PR DESCRIPTION

Se implementa la generación explícita de token QR para visitas registradas.

## Cambios
- El registro de visitante ahora crea la visita/acceso sin generar QR automáticamente.
- Se agrega endpoint para generar QR bajo demanda:
  `POST /api/visitante/accesos/:idAcceso/generar-qr`
- Se agrega consulta de detalle de visita:
  `GET /api/visitante/accesos/:idAcceso`
- Se agrega consulta de QR para guardia/admin:
  `GET /api/visitante/qr/:codigoQr`
- El QR generado es un token seguro y no contiene datos sensibles en texto plano.
- Se valida que el acceso pertenezca al residente autenticado.
- Se marca como inválido/inactivo si la visita ya expiró.
- La foto del visitante deja de ser obligatoria para registrar la visita.

## Pruebas
- Login con cuenta residente.
- Registro de visitante desde Yaak.
- Generación de QR con `id_acceso`.
- Consulta del token QR generado.
- Build ejecutado correctamente con `npm run build`.